### PR TITLE
Add support for PowerSupplyInformation record in MultiRecord area

### DIFF
--- a/frugy/multirecords_ipmi.py
+++ b/frugy/multirecords_ipmi.py
@@ -30,6 +30,65 @@ fmc_output_constants = {name: idx for idx,
                         name in enumerate(fmc_voltages_total)}
 
 
+@ipmi_multirecord(0x00)
+class PowerSupplyInformation(MultirecordEntry):
+    ''' Platform Management FRU Information Storage Definition, Table 18-1 '''
+
+    # Need to see the fields as big-endian so that 12-bit sub-fields can be
+    # properly extracted from 2-byte fields.
+    _mergeBitfield = True
+
+    # TODO: add unit metadata to fields
+    _schema = [
+        ('predictive_fail_lower_thresh', FixedField, 'u8'),
+        ('combined_wattage', FixedField, 'u16', {'constants': {
+            'no_combined_voltages': 0
+        }}),
+        ('voltage1', FixedField, 'u4', {'constants': {
+            '12v': 0,
+            '-12v': 1,
+            '5v': 2,
+            '3.3v': 3,
+        }}),
+        ('voltage2', FixedField, 'u4', {'constants': {
+            '12v': 0,
+            '-12v': 1,
+            '5v': 2,
+            '3.3v': 3,
+        }}),
+        ('holdup_time', FixedField, 'u4'),
+        ('peak_capacity', FixedField, 'u12', {'constants': {
+            'unspecified': 0xfff
+        }}),
+        ('_reserved2', FixedField, 'u3', {'default': 0}),
+        ('pin_polarity', FixedField, 'u1'),
+        ('hot_swap', FixedField, 'u1'),
+        ('autoswitch', FixedField, 'u1'),
+        ('pfc', FixedField, 'u1'),
+        ('predictive_fail_support', FixedField, 'u1'),
+        ('dropout_tolerance', FixedField, 'u8'),
+        ('high_freq', FixedField, 'u8', {'constants': {
+            'only_dc': 0
+        }}),
+        ('low_freq', FixedField, 'u8', {'constants': {
+            'accepts_dc': 0
+        }}),
+        ('high_input_voltage_2', FixedField, 's16', {'div': 10}),     # 10mV
+        ('low_input_voltage_2', FixedField, 's16', {'div': 10}),     # 10mV
+        ('high_input_voltage_1', FixedField, 's16', {'div': 10}),     # 10mV
+        ('low_input_voltage_1', FixedField, 's16', {'div': 10}),     # 10mV
+        ('inrush_interval', FixedField, 'u8'),
+        ('inrush_current', FixedField, 'u8', {'constants': {
+            'unspecified': 0xff
+        }}),
+        ('peak_va', FixedField, 'u16', {'constants': {
+            'unspecified': 0xffff
+        }}),
+        ('_reserved', FixedField, 'u4', {'default': 0}),
+        ('overall_capacity', FixedField, 'u12'),
+    ]
+
+
 @ipmi_multirecord(0x01)
 class DCOutput(MultirecordEntry):
     ''' Platform Management FRU Information Storage Definition, Table 18-2 '''


### PR DESCRIPTION
There was no nice way to represent 12-bit fields as `FixedField`-s because the bits appear to be disjoint with the bit and byte orders that are used: MSB first for bits, LSB first for bytes.
Here is an illustration of two fields, 4-bit field A and 12-bit field B, where field A is located in the most significant bits of a little-endian 2-byte memory area:
```
B7 B6 B5 B4 B3 B2 B1 B0  A3 A2 A1 A0 B11 B10 B9 B8
```
I could not find any way to unpack A and B using `bitstruct`.

So, I had to resort to using `_mergeBitfield=True`.
That flag reverses the order of all bytes in a record, thus, converting any multi-byte little-endian fields to big-endian.  That way, the bytes and bits have the same ordering and the sub-fields become contiguous:
```
A3 A2 A1 A0 B11 B10 B9 B8  B7 B6 B5 B4 B3 B2 B1 B0
```
`bitstruct` can handle this bit order naturally.

As a result of using `_mergeBitfield`,  bytes are defined in the opposite order comparing to Table 18-1.

Also, a note that I was quite liberal with naming of the fields because the specification names are quite verbose.

And I did not do anything about field dependencies.
E.g., `pin_polarity` could mean either  "Tachometer pulses per rotation" or "Predictive fail pin polarity" depending whether predictive fail pin is supported.
I think that it would be too hard to codify that for a very little benefit.