### PR TITLE
Refactor IPMI OEM record handling and add support for Vadatech OEM record 0xc0

### DIFF
--- a/docs/records.md
+++ b/docs/records.md
@@ -22,6 +22,14 @@
 |DCOutput                            |Platform Management FRU Information Storage Definition, Table 18-2              |
 |DCLoad                              |Platform Management FRU Information Storage Definition, Table 18-4              |
 |MgmtAccessRecord                    |Platform Management FRU Information Storage Definition, Table 18-6              |
+
+<br>
+
+
+## oem_multirecord
+
+|Name                                |Definition                                                                      |
+|------------------------------------|--------------------------------------------------------------------------------|
 |PicmgEntry                          |PICMG AMC.0 Specification R2.0                                                  |
 |FmcEntry                            |ANSI/VITA 57.1 FMC Standard                                                     |
 |OemXilinxEntry                      |Xilinx proprietary, not published                                               |

--- a/docs/records.md
+++ b/docs/records.md
@@ -34,6 +34,7 @@
 |FmcEntry                            |ANSI/VITA 57.1 FMC Standard                                                     |
 |OemXilinxEntry                      |Xilinx proprietary, not published                                               |
 |OemXilinxD3Entry                    |Xilinx proprietary, not published                                               |
+|OemVadatechC0Entry                  |VadaTech proprietary OEM multirecord (type 0xC0), opaque hex payload            |
 
 <br>
 

--- a/frugy/fru.py
+++ b/frugy/fru.py
@@ -18,6 +18,7 @@ import frugy.multirecords_ipmi
 import frugy.multirecords_picmg
 import frugy.multirecords_fmc
 import frugy.multirecords_xilinx
+import frugy.multirecords_vadatech
 import yaml
 from bidict import bidict
 import os

--- a/frugy/fru_registry.py
+++ b/frugy/fru_registry.py
@@ -7,6 +7,7 @@
 #                                                                                  #
 #          Copyright 2021 Deutsches Elektronen-Synchrotron DESY.                   #
 # Modifications Copyright(C) 2025 Advanced Micro Devices, Inc. All rights reserved #
+#                            2026 Atom Computing, Inc.                             #
 #                  SPDX-License-Identifier: BSD-3-Clause                           #
 #                                                                                  #
 ####################################################################################
@@ -19,6 +20,7 @@ from itertools import chain
 class FruRecordType(Enum):
     ipmi_area = auto()
     ipmi_multirecord = auto()
+    oem_multirecord = auto()
     picmg_multirecord = auto()
     picmg_secondary = auto()
     fmc_multirecord = auto()
@@ -31,6 +33,10 @@ _registry = defaultdict(list)
 _lookup_by_id = defaultdict(dict)
 _lookup_by_name = {}
 
+# OEM router lookup, keyed by (type_id, iana_enterprise_number).
+# Populated by `rec_register_oem` via the `@oem_multirecord` decorator.
+_lookup_oem = {}
+
 
 def rec_register(cls, rec_type: FruRecordType, rec_id=None):
     ''' Register FRU record type in central registry and lookup table '''
@@ -38,6 +44,41 @@ def rec_register(cls, rec_type: FruRecordType, rec_id=None):
     _lookup_by_name[cls.__name__] = cls
     if rec_id is not None:
         _lookup_by_id[rec_type][rec_id] = cls
+
+
+def rec_register_oem(cls, type_id: int, iana: int):
+    ''' Register an OEM multirecord superclass under (type_id, IANA Enterprise Number).
+
+    OEM records share the same IPMI `type_id` (0xC0-0xFF) across vendors; the
+    actual vendor is encoded in the IANA Enterprise Number prologue of the
+    payload (see IPMI Platform Management FRU Information Storage Definition,
+    section 18.7). Registering by the tuple lets multiple vendors coexist on
+    the same `type_id`.
+    '''
+    _registry[FruRecordType.oem_multirecord].append(cls)
+    _lookup_by_name[cls.__name__] = cls
+    _lookup_oem[(type_id, iana)] = cls
+
+
+def rec_lookup_oem(type_id: int, iana: int):
+    ''' Lookup OEM multirecord superclass by (type_id, IANA Enterprise Number). '''
+    return _lookup_oem[(type_id, iana)]
+
+
+def rec_lookup_oem_unique(type_id: int):
+    ''' Return the single OEM vendor registered for `type_id`.
+
+    Used by escape hatches like the Opal Kelly FMC workaround that need to
+    dispatch without an IANA prologue. Raises `KeyError` if zero or multiple
+    vendors are registered for this `type_id`.
+    '''
+    matches = [cls for (tid, _iana), cls in _lookup_oem.items()
+               if tid == type_id]
+    if len(matches) != 1:
+        raise KeyError(
+            f"Expected exactly one OEM vendor for type_id=0x{type_id:02x}, "
+            f"found {len(matches)}")
+    return matches[0]
 
 
 def rec_enumerate(rec_type_filter=None):

--- a/frugy/multirecords.py
+++ b/frugy/multirecords.py
@@ -6,16 +6,28 @@
 #  /_____/_____//____/  /_/      T  E  C  H  N  O  L  O  G  Y   L A B     #
 #                                                                         #
 #          Copyright 2021 Deutsches Elektronen-Synchrotron DESY.          #
+#                    2026 Atom Computing, Inc.
 #                  SPDX-License-Identifier: BSD-3-Clause                  #
 #                                                                         #
 ###########################################################################
 
 from frugy.types import FruAreaBase, FixedField, FixedStringField, GuidField, ArrayField, BytearrayField, IpV4Field, bin2hex_helper
 import bitstruct
-from frugy.fru_registry import FruRecordType, rec_register, rec_lookup_by_id, rec_lookup_by_name
+from frugy.fru_registry import (
+    FruRecordType,
+    rec_register,
+    rec_register_oem,
+    rec_lookup_by_id,
+    rec_lookup_by_name,
+    rec_lookup_oem,
+    rec_lookup_oem_unique,
+)
 from frugy.areas import ipmi_area
 import logging
 import frugy.fru
+
+
+OEM_TYPE_ID_RANGE = range(0xC0, 0x100)
 
 
 @ipmi_area
@@ -137,11 +149,40 @@ class MultirecordEntry(FruAreaBase):
                 end_of_list = 1
                 raise RuntimeError("MultirecordEntry payload checksum invalid")
 
-            try:
-                cls_id = rec_lookup_by_id(
-                    FruRecordType.ipmi_multirecord, type_id)
-            except KeyError:
-                raise RuntimeError(f"Unknown multirecord type 0x{type_id:02x}")
+            if type_id in OEM_TYPE_ID_RANGE:
+                # OEM record (IPMI spec 18.7): first 3 payload bytes are the
+                # IANA Enterprise Number identifying the vendor. The router
+                # dispatches on (type_id, IANA) so multiple vendors can share
+                # the same type_id (e.g. PICMG and VadaTech both use 0xC0).
+                if MultirecordEntry.opalkelly_workaround_enabled and type_id == 0xFA:
+                    # Opal Kelly FMC variant omits the IANA prologue, so we
+                    # cannot peek it. Fall back to the unique vendor for 0xFA.
+                    try:
+                        cls_id = rec_lookup_oem_unique(type_id)
+                    except KeyError:
+                        raise RuntimeError(
+                            f"Unknown multirecord type 0x{type_id:02x}")
+                else:
+                    if len(payload) < 3:
+                        raise ValueError(
+                            f"OEM payload too short to contain IANA Enterprise Number "
+                            f"(type_id=0x{type_id:02x}, len={len(payload)})")
+                    iana = int.from_bytes(payload[:3], 'little')
+                    try:
+                        cls_id = rec_lookup_oem(type_id, iana)
+                    except KeyError:
+                        # No decoder registered for this (type_id, IANA) pair:
+                        # treat as private/proprietary and silently drop.
+                        raise ValueError(
+                            f"No decoder registered for OEM multirecord "
+                            f"(type_id=0x{type_id:02x}, IANA=0x{iana:06x})")
+            else:
+                try:
+                    cls_id = rec_lookup_by_id(
+                        FruRecordType.ipmi_multirecord, type_id)
+                except KeyError:
+                    raise RuntimeError(
+                        f"Unknown multirecord type 0x{type_id:02x}")
 
             if hasattr(cls_id, 'from_payload'):
                 new_entry = cls_id.from_payload(payload)
@@ -180,9 +221,30 @@ class MultirecordEntry(FruAreaBase):
         return new_entry, remainder, end_of_list
 
 
-def ipmi_multirecord(rec_id):
+def ipmi_standard_record(type_id):
+    ''' Register a standard IPMI multirecord (type_id 0x00-0x05).
+
+    See IPMI Platform Management FRU Information Storage Definition, Table 18-1
+    through Table 18-6 for the predefined standard record types.
+    '''
     def register_and_set_id(cls):
-        cls._type_id = rec_id
-        rec_register(cls, FruRecordType.ipmi_multirecord, rec_id)
+        cls._type_id = type_id
+        rec_register(cls, FruRecordType.ipmi_multirecord, type_id)
+        return cls
+    return register_and_set_id
+
+
+def oem_multirecord(type_id, vendor_iana):
+    ''' Register an OEM multirecord superclass under (type_id, vendor_iana).
+
+    OEM record types (0xC0-0xFF, see IPMI spec 18.7) use the first three
+    payload bytes as an IANA Enterprise Number to identify the vendor. The
+    router in `MultirecordEntry.deserialize` dispatches on this tuple so
+    several vendors can coexist at the same `type_id`.
+    '''
+    def register_and_set_id(cls):
+        cls._type_id = type_id
+        cls._vendor_iana = vendor_iana
+        rec_register_oem(cls, type_id, vendor_iana)
         return cls
     return register_and_set_id

--- a/frugy/multirecords_fmc.py
+++ b/frugy/multirecords_fmc.py
@@ -6,41 +6,37 @@
 #  /_____/_____//____/  /_/      T  E  C  H  N  O  L  O  G  Y   L A B     #
 #                                                                         #
 #          Copyright 2021 Deutsches Elektronen-Synchrotron DESY.          #
+#                    2026 Atom Computing, Inc.                            #
 #                  SPDX-License-Identifier: BSD-3-Clause                  #
 #                                                                         #
 ###########################################################################
 
 from frugy.types import FixedField, BytearrayField, ser_6bit, deser_6bit
-from frugy.multirecords import ipmi_multirecord, MultirecordEntry
+from frugy.multirecords import oem_multirecord, MultirecordEntry
 from frugy.fru_registry import FruRecordType, rec_register, rec_lookup_by_id
 
 import bitstruct
 from bidict import bidict
 
+VITA_IDENTIFIER = 0x12a2
 
-@ipmi_multirecord(0xfa)
+@oem_multirecord(0xfa, VITA_IDENTIFIER)
 class FmcEntry(MultirecordEntry):
     ''' ANSI/VITA 57.1 FMC Standard '''
     ''' Superclass of all ANSI/VITA FMC OEM multirecords '''
 
-    _fmc_identifier = 0x12a2
-
     def _payload_prologue(self):
-        return self._fmc_identifier.to_bytes(3, 'little') + self._record_id.to_bytes(length=1, byteorder='little')
+        return VITA_IDENTIFIER.to_bytes(3, 'little') + self._record_id.to_bytes(length=1, byteorder='little')
 
     @classmethod
     def from_payload(cls, payload):
         if not MultirecordEntry.opalkelly_workaround_enabled:
-            # Opal Kelly FMC records seem to skip the manufacturer ID ...
-            fmc_id, payload = payload[:3], payload[3:]
+            # IANA prologue already validated by the OEM router; just skip it.
+            payload = payload[3:]
             rec_id, payload = payload[0], payload[1:]
-            fmc_id = int.from_bytes(fmc_id, 'little')
-
-            if fmc_id != cls._fmc_identifier:
-                raise ValueError(
-                    f"FMC identifier mismatch: expected 0x{cls._fmc_identifier:06x}, received 0x{fmc_id:06x} ({fmc_id})")
         else:
-            # Opal Kelly FMC records seem to have the rec_id as _last_ instead of first byte
+            # Opal Kelly FMC records skip the IANA prologue and put rec_id as
+            # the _last_ byte of the payload instead of the first.
             rec_id, payload = payload[-1], payload[:-1]
 
         try:

--- a/frugy/multirecords_ipmi.py
+++ b/frugy/multirecords_ipmi.py
@@ -11,7 +11,7 @@
 ###########################################################################
 
 from frugy.types import FixedField, BytearrayField
-from frugy.multirecords import ipmi_multirecord, MultirecordEntry
+from frugy.multirecords import ipmi_standard_record, MultirecordEntry
 
 
 # IPMI standard multirecords
@@ -30,7 +30,7 @@ fmc_output_constants = {name: idx for idx,
                         name in enumerate(fmc_voltages_total)}
 
 
-@ipmi_multirecord(0x00)
+@ipmi_standard_record(0x00)
 class PowerSupplyInformation(MultirecordEntry):
     ''' Platform Management FRU Information Storage Definition, Table 18-1 '''
 
@@ -89,7 +89,7 @@ class PowerSupplyInformation(MultirecordEntry):
     ]
 
 
-@ipmi_multirecord(0x01)
+@ipmi_standard_record(0x01)
 class DCOutput(MultirecordEntry):
     ''' Platform Management FRU Information Storage Definition, Table 18-2 '''
 
@@ -108,7 +108,7 @@ class DCOutput(MultirecordEntry):
     ]
 
 
-@ipmi_multirecord(0x02)
+@ipmi_standard_record(0x02)
 class DCLoad(MultirecordEntry):
     ''' Platform Management FRU Information Storage Definition, Table 18-4 '''
 
@@ -125,7 +125,7 @@ class DCLoad(MultirecordEntry):
     ]
 
 
-@ipmi_multirecord(0x03)
+@ipmi_standard_record(0x03)
 class MgmtAccessRecord(MultirecordEntry):
     ''' Platform Management FRU Information Storage Definition, Table 18-6 '''
 

--- a/frugy/multirecords_picmg.py
+++ b/frugy/multirecords_picmg.py
@@ -7,42 +7,38 @@
 #                                                                         #
 #          Copyright 2021 Deutsches Elektronen-Synchrotron DESY.          #
 #                    2022 Atom Computing, Inc                             #
+#                    2026 Atom Computing, Inc                             #
 #                  SPDX-License-Identifier: BSD-3-Clause                  #
 #                                                                         #
 ###########################################################################
 
 from frugy.types import FruAreaBase, FixedField, FixedStringField, GuidField, ArrayField, BytearrayField, IpV4Field, bin2hex_helper, _grouper
-from frugy.multirecords import ipmi_multirecord, MultirecordEntry
+from frugy.multirecords import oem_multirecord, MultirecordEntry
 from frugy.fru_registry import FruRecordType, rec_register, rec_lookup_by_id
 
 import re
 import logging
 
+PICMG_IDENTIFIER = 0x315a
 
-@ipmi_multirecord(0xc0)
+@oem_multirecord(0xc0, PICMG_IDENTIFIER)
 class PicmgEntry(MultirecordEntry):
     ''' PICMG AMC.0 Specification R2.0 '''
     ''' Superclass of all PICMG OEM multirecords '''
-
-    _picmg_identifier = 0x315a
 
     def format_version(self):
         return 0x00
 
     def _payload_prologue(self):
-        return self._picmg_identifier.to_bytes(3, 'little') \
+        return PICMG_IDENTIFIER.to_bytes(3, 'little') \
             + self._record_id.to_bytes(length=1, byteorder='little') \
             + self.format_version().to_bytes(length=1, byteorder='little')
 
     @classmethod
     def from_payload(cls, payload):
-        picmg_id, payload = payload[:3], payload[3:]
+        # IANA prologue already validated by the OEM router; just skip it.
+        payload = payload[3:]
         rec_id, rec_fmt_version, payload = payload[0], payload[1], payload[2:]
-        picmg_id = int.from_bytes(picmg_id, 'little')
-
-        if picmg_id != cls._picmg_identifier:
-            raise ValueError(
-                f"PICMG identifier mismatch: expected 0x{cls._picmg_identifier:06x}, received 0x{picmg_id:06x} ({picmg_id})")
 
         if rec_fmt_version not in [0x00, 0x01]:
             raise RuntimeError(

--- a/frugy/multirecords_vadatech.py
+++ b/frugy/multirecords_vadatech.py
@@ -1,0 +1,41 @@
+# Copyright 2026 Atom Computing, Inc.
+# SPDX-License-Identifier: BSD-3-Clause
+
+from frugy.types import BytearrayField
+from frugy.multirecords import oem_multirecord, MultirecordEntry
+
+
+# VadaTech OEM multirecords
+#
+# IANA Enterprise Number 23858 (0x005d32) is registered to VadaTech, Inc.
+# Their proprietary multirecord layouts are not published, so we cannot
+# decode the payload into structured fields. Instead we round-trip it as
+# an opaque hex blob so that FRU images containing VadaTech records can be
+# parsed, edited and re-emitted without losing the vendor data.
+
+VADATECH_IDENTIFIER = 0x005d32
+
+
+class _OemVadatechBase(MultirecordEntry):
+    ''' Base class for opaque VadaTech OEM multirecords (hex blob). '''
+
+    _schema = [
+        ('data', BytearrayField, None, {'hex': True}),
+    ]
+
+    def _payload_prologue(self):
+        return VADATECH_IDENTIFIER.to_bytes(3, 'little')
+
+    @classmethod
+    def from_payload(cls, payload):
+        # IANA prologue already validated by the OEM router; just skip it.
+        payload = payload[3:]
+        cls_inst = cls()
+        cls_inst._deserialize(payload)
+        return cls_inst
+
+
+@oem_multirecord(0xc0, VADATECH_IDENTIFIER)
+class OemVadatechC0Entry(_OemVadatechBase):
+    ''' VadaTech proprietary OEM multirecord (type 0xC0), opaque hex payload '''
+    pass

--- a/frugy/multirecords_xilinx.py
+++ b/frugy/multirecords_xilinx.py
@@ -7,37 +7,33 @@
 #                                                                          #
 #          Copyright 2021 Deutsches Elektronen-Synchrotron DESY.           #
 #                    2025 Advanced Micro Devices, Inc. All rights reserved #
+#                    2026 Atom Computing, Inc.                             #
 #                  SPDX-License-Identifier: BSD-3-Clause                   #
 #                                                                          #
 ############################################################################
 
 from frugy.types import *
-from frugy.multirecords import ipmi_multirecord, MultirecordEntry
+from frugy.multirecords import oem_multirecord, MultirecordEntry
 from frugy.fru_registry import FruRecordType, rec_register, rec_lookup_by_id
 
 
-# IPMI standard multirecords
+# Xilinx OEM multirecords
 
+XILINX_IDENTIFIER = 0x10da
 
-@ipmi_multirecord(0xd2)
+@oem_multirecord(0xd2, XILINX_IDENTIFIER)
 class OemXilinxEntry(MultirecordEntry):
     ''' Xilinx proprietary, not published '''
 
-    _xilinx_identifier = 0x10da
-
     def _payload_prologue(self):
-        return self._xilinx_identifier.to_bytes(3, 'little') + self._record_id.to_bytes(length=1, byteorder='little')
+        return XILINX_IDENTIFIER.to_bytes(3, 'little') + self._record_id.to_bytes(length=1, byteorder='little')
 
     @classmethod
     def from_payload(cls, payload):
-        xilinx_id, payload = payload[:3], payload[3:]
-        xilinx_id = int.from_bytes(xilinx_id, 'little')
+        # IANA prologue already validated by the OEM router; just skip it.
+        payload = payload[3:]
         rec_id, payload = payload[0], payload[1:]
 
-
-        if xilinx_id != cls._xilinx_identifier:
-            raise ValueError(
-                f"FMC identifier mismatch: expected 0x{cls._xilinx_identifier:06x}, received 0x{xilinx_id:06x} ({xilinx_id})")
         try:
             cls_inst = rec_lookup_by_id(
                 FruRecordType.xilinx_multirecord, rec_id)()
@@ -49,14 +45,12 @@ class OemXilinxEntry(MultirecordEntry):
         return cls_inst
 
 
-@ipmi_multirecord(0xd3)
+@oem_multirecord(0xd3, XILINX_IDENTIFIER)
 class OemXilinxD3Entry(MultirecordEntry):
     ''' Xilinx proprietary, not published '''
 
-    _xilinx_identifier = 0x10da
-
     def _payload_prologue(self):
-        return self._xilinx_identifier.to_bytes(3, 'little')
+        return XILINX_IDENTIFIER.to_bytes(3, 'little')
 
     @classmethod
     def from_payload(cls, payload):

--- a/frugy/types.py
+++ b/frugy/types.py
@@ -292,7 +292,8 @@ class FixedStringField():
         return self._bufsize * 8
 
     def serialize(self) -> bytearray:
-        return self._value[:self._bufsize-1].encode(_en_decode) + self._null_term
+        encoded = self._value[:self._bufsize-1].encode(_en_decode) + self._null_term
+        return encoded + b'\x00' * (self._bufsize - len(encoded))
 
     def deserialize(self, input: bytearray) -> bytearray:
         tmp, remainder = input[:self._bufsize], input[self._bufsize:]


### PR DESCRIPTION
- Introduced `rec_register_oem` and `rec_lookup_oem` functions for handling OEM multirecords.
- Updated `MultirecordEntry` to support OEM records by dispatching based on (type_id, IANA Enterprise Number).
- Refactored existing multirecord decorators to use the new OEM registration methods.
- Adjusted related multirecord classes to accommodate the new structure, including Xilinx and FMC entries.
- Add support for Vadatech OEM multirecord `0xc0`